### PR TITLE
Fix authorization on iOS11, add support for CSRF

### DIFF
--- a/TransmissionRPCClient/RPCConnector.h
+++ b/TransmissionRPCClient/RPCConnector.h
@@ -36,7 +36,7 @@
 @end
 
 
-@interface RPCConnector : NSObject
+@interface RPCConnector<NSURLSessionDataDelegate, NSURLSessionTaskDelegate> : NSObject
 
 @property(nonatomic) NSString *lastErrorMessage;
 


### PR DESCRIPTION
Hi there,

I have fixed logging in on iOS 11. Setting the Authorization header didn't work for some reason so I used NSURLSessionDelegate to handle the auth challenge.

I also added support for handling CSRF via returning the session cookie in the 'X-Transmission-Session-Id' header.