### PR TITLE
Display 401 error notifier instead of generic 'cancelled'

### DIFF
--- a/TransmissionRPCClient/RPCConnector.m
+++ b/TransmissionRPCClient/RPCConnector.m
@@ -517,6 +517,7 @@
                     if( statusCode == HTTP_RESPONSE_UNAUTHORIZED )
                         _lastErrorMessage = @"You are unauthorized to access server";
                     
+                    
                     [self sendErrorMessage:[NSString stringWithFormat:@"%li %@", (long)statusCode, _lastErrorMessage]
                           toDelegateWithRequestMethodName:requestName];
                 }
@@ -608,7 +609,8 @@
         else
         {
             NSLog(@"%s; challenge.error = %@", __FUNCTION__, challenge.error);
-            completionHandler(NSURLSessionAuthChallengeCancelAuthenticationChallenge, nil);
+            // Use default handling so a 401 error message is displayed instead of 'cancelled'
+            completionHandler(NSURLSessionAuthChallengePerformDefaultHandling, nil);
         }
     }
 }


### PR DESCRIPTION
I noticed that in my previous change (#1), the notification on invalid login credentials wasn't particularly useful. It just said 'canceled'.

This change fixes that so a proper 401 error notification is displayed.  