### PR TITLE
Fix handling long passwords

### DIFF
--- a/TransmissionRPCClient/RPCConnector.m
+++ b/TransmissionRPCClient/RPCConnector.m
@@ -869,7 +869,7 @@
             
             NSString *authStringToEncode64 = [NSString stringWithFormat:@"%@:%@", config.userName, config.userPassword];
             NSData *data = [authStringToEncode64 dataUsingEncoding:NSUTF8StringEncoding];
-            _authString = [NSString stringWithFormat:@"Basic %@", [data base64EncodedStringWithOptions:NSDataBase64Encoding64CharacterLineLength]];
+            _authString = [NSString stringWithFormat:@"Basic %@", [data base64EncodedStringWithOptions:0]];
         }
     }
     


### PR DESCRIPTION
This pull-request super-seeds #4.

I found that long connecting to a server that uses a long password can result in a 401. The reason being that the implementation is adding a line break at every 64 characters in the authorization string, therefore if the base64 representation of the authorization header is longer than 64 characters, the authorization won't succeed.

To fix that, I removed the 64 character line break base64Encoding option.